### PR TITLE
Agregar script data_preprocesing.py 

### DIFF
--- a/src/data_preprocessing.py
+++ b/src/data_preprocessing.py
@@ -1,1 +1,9 @@
 import numpy as np
+
+def preprocess_data_for_mlp(x_train, x_test):
+    """Realiza el preprocesamiento para la MLP (aplanado de imágenes)."""
+    # Aplanar las imágenes de 28x28 a 784 (28*28) y normalizar los valores (0 a 255) a un rango de 0 a 1
+    x_train_mlp = x_train.reshape(x_train.shape[0], -1).astype('float32') / 255.0
+    x_test_mlp = x_test.reshape(x_test.shape[0], -1).astype('float32') / 255.0
+
+    return x_train_mlp, x_test_mlp

--- a/src/data_preprocessing.py
+++ b/src/data_preprocessing.py
@@ -1,1 +1,1 @@
-# Data cleaning and preprocessing code here
+import numpy as np

--- a/src/data_preprocessing.py
+++ b/src/data_preprocessing.py
@@ -7,3 +7,9 @@ def preprocess_data_for_mlp(x_train, x_test):
     x_test_mlp = x_test.reshape(x_test.shape[0], -1).astype('float32') / 255.0
 
     return x_train_mlp, x_test_mlp
+
+def preprocess_data_for_cnn(x_train, x_test):
+    """Realiza el preprocesamiento para la CNN (mantener imágenes 2D y normalizar)."""
+    # Normalizar las imágenes (su valor de cada pixel va de 0 a 255) entre 0 y 1
+    x_train_cnn = x_train.astype('float32') / 255.0
+    x_test_cnn = x_test.astype('float32') / 255.0

--- a/src/data_preprocessing.py
+++ b/src/data_preprocessing.py
@@ -13,3 +13,11 @@ def preprocess_data_for_cnn(x_train, x_test):
     # Normalizar las imágenes (su valor de cada pixel va de 0 a 255) entre 0 y 1
     x_train_cnn = x_train.astype('float32') / 255.0
     x_test_cnn = x_test.astype('float32') / 255.0
+
+    # Comprobacion de que las imagenes estén en el formato adecuado para las CNN (28x28x1)
+    # (28, 28) para las imágenes
+    # 1 para el canal de color (escala de grises)
+    x_train_cnn = np.expand_dims(x_train_cnn, axis=-1)
+    x_test_cnn = np.expand_dims(x_test_cnn, axis=-1)
+
+    return x_train_cnn, x_test_cnn


### PR DESCRIPTION
Se ha creado data_preprocessing.py y escrito (en ese script) el codigo necesario para el preprocesamiento de los datos MNIST que se hayan descargado. Algunas de las funciones que se crearon:
- Preprocesamiento de los datos para una MLP (normalizado y aplanado de las imagenes)
- Preprocesamiento de los datos para una CNN (normalizado y expansion de dimensiones de las imagenes)