### PR TITLE
Agregar data_pipeline junto con las modificaciones en data_processing

### DIFF
--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -45,7 +45,7 @@ def load_data():
     print("Datos MNIST cargados (y procesados) desde /data/raw")
     return (train_images, train_labels), (test_images, test_labels)
 
-def save_preprocessed_data(x_train_mlp, x_test_mlp, x_train_cnn, x_test_cnn):
+def save_preprocessed_data(x_train_mlp, x_test_mlp, x_train_cnn, x_test_cnn, y_train, y_test):
     """Guarda los datos preprocesados en /data/preprocessed"""
     preprocessed_dir = os.path.join('.', 'data', 'preprocessed')
     os.makedirs(preprocessed_dir, exist_ok=True)
@@ -56,7 +56,9 @@ def save_preprocessed_data(x_train_mlp, x_test_mlp, x_train_cnn, x_test_cnn):
     train_cnn_file = os.path.join(preprocessed_dir, 'train_cnn.npy')
     test_cnn_file = os.path.join(preprocessed_dir, 'test_cnn.npy')
 
-
+    # Rutas de guardado para las etiquetas preprocesadas
+    train_labels_file = os.path.join(preprocessed_dir, 'train_labels.npy')
+    test_labels_file = os.path.join(preprocessed_dir, 'test_labels.npy')
 
 def run_data_pipeline():
     """Organiza la descarga, carga y procesamiento de los datos sde MNIST"""

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -43,3 +43,8 @@ def load_data():
 
     print("Datos MNIST cargados (y procesados) desde /data/raw")
     return (train_images, train_labels), (test_images, test_labels)
+
+def run_data_pipeline():
+    """Organiza la descarga, carga y procesamiento de los datos de MNIST"""
+    # Descargar y guardar los datos de MNIST en formato raw
+    download_raw_data()

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -2,4 +2,11 @@ import tensorflow as tf
 import numpy as np
 import os
 
+def download_raw_data():
+    """Descarga MNIST original y lo guarda en /data/raw en formato raw"""
+    mnist = tf.keras.datasets.mnist
+    (x_train, y_train), (x_test, y_test) = mnist.load_data()
 
+    
+    
+    

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -7,6 +7,6 @@ def download_raw_data():
     mnist = tf.keras.datasets.mnist
     (x_train, y_train), (x_test, y_test) = mnist.load_data()
 
-    
-    
-    
+    # Directorio para guardar MNIST y comprobacion de su existencia
+    output_dir = './data/raw'
+    os.makedirs(output_dir, exist_ok=True)

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -40,3 +40,6 @@ def load_data():
     train_labels = np.fromfile(train_labels_file, dtype=np.uint8)
     test_images = np.fromfile(test_images_file, dtype=np.uint8).reshape(-1, 28, 28)
     test_labels = np.fromfile(test_labels_file, dtype=np.uint8)
+
+    print("Datos MNIST cargados (y procesados) desde /data/raw")
+    return (train_images, train_labels), (test_images, test_labels)

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -1,6 +1,7 @@
 import tensorflow as tf
 import numpy as np
 import os
+from src.data_preprocessing import *
 
 def download_raw_data():
     """Descarga MNIST original y lo guarda en /data/raw en formato raw"""
@@ -49,5 +50,13 @@ def run_data_pipeline():
     # Descargar y guardar los datos de MNIST en formato raw
     download_raw_data()
 
-    # Cargar los datos raw de MNIST 
+    # Cargar los datos raw de MNIST
     (x_train, y_train), (x_test, y_test) = load_data()
+
+    # Preprocesar los datos para una MLP
+    x_train_mlp, x_test_mlp = preprocess_data_for_mlp(x_train, x_test)
+    print("Datos preprocesados para MLP listos.")
+
+    # Preprocesar los datos para una CNN
+    x_train_cnn, x_test_cnn = preprocess_data_for_cnn(x_train, x_test)
+    print("Datos preprocesados para CNN listos.")

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -92,3 +92,6 @@ def run_data_pipeline():
     save_preprocessed_data(x_train_mlp, x_test_mlp, x_train_cnn, x_test_cnn, y_train_one_hot, y_test_one_hot)
     print("Imagenes y etiquetas preprocesadas guardadas en /data/preprocessed")
 
+if __name__ == '__main__':
+    # Ejecutar el data_pipeline
+    run_data_pipeline()

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -48,3 +48,6 @@ def run_data_pipeline():
     """Organiza la descarga, carga y procesamiento de los datos de MNIST"""
     # Descargar y guardar los datos de MNIST en formato raw
     download_raw_data()
+
+    # Cargar los datos raw de MNIST 
+    (x_train, y_train), (x_test, y_test) = load_data()

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -22,3 +22,14 @@ def download_raw_data():
     y_train.tofile(train_labels_file)
     x_test.tofile(test_images_file)
     y_test.tofile(test_labels_file)
+
+    print("Imagenes y etiquetas de MNIST guardados (formato raw) en /data/raw")
+
+def load_data():
+    """Carga los datos de MNIST en formato raw"""
+    raw_dir = os.path.join('.', 'data', 'raw')
+
+    train_images_file = os.path.join(raw_dir, 'train_images.raw')
+    train_labels_file = os.path.join(raw_dir, 'train_labels.raw')
+    test_images_file = os.path.join(raw_dir, 'test_images.raw')
+    test_labels_file = os.path.join(raw_dir, 'test_labels.raw')

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -56,6 +56,8 @@ def save_preprocessed_data(x_train_mlp, x_test_mlp, x_train_cnn, x_test_cnn):
     train_cnn_file = os.path.join(preprocessed_dir, 'train_cnn.npy')
     test_cnn_file = os.path.join(preprocessed_dir, 'test_cnn.npy')
 
+
+
 def run_data_pipeline():
     """Organiza la descarga, carga y procesamiento de los datos sde MNIST"""
     # Descargar y guardar los datos de MNIST en formato raw
@@ -71,3 +73,7 @@ def run_data_pipeline():
     # Preprocesar los datos para una CNN
     x_train_cnn, x_test_cnn = preprocess_data_for_cnn(x_train, x_test)
     print("Datos preprocesados para CNN listos.")
+
+    # Preprocesar las etiquetas (formato one-hot encoding)
+    y_train_one_hot, y_test_one_hot = preprocess_labels(y_train, y_test)
+    print("Etiquetas preprocesadas listas.")

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -60,6 +60,14 @@ def save_preprocessed_data(x_train_mlp, x_test_mlp, x_train_cnn, x_test_cnn, y_t
     train_labels_file = os.path.join(preprocessed_dir, 'train_labels.npy')
     test_labels_file = os.path.join(preprocessed_dir, 'test_labels.npy')
 
+    # Guardar las imagenes y etiquetas preprocesadas
+    np.save(train_mlp_file, x_train_mlp)
+    np.save(test_mlp_file, x_test_mlp)
+    np.save(train_cnn_file, x_train_cnn)
+    np.save(test_cnn_file, x_test_cnn)
+    np.save(train_labels_file, y_train)
+    np.save(test_labels_file, y_test)
+
 def run_data_pipeline():
     """Organiza la descarga, carga y procesamiento de los datos sde MNIST"""
     # Descargar y guardar los datos de MNIST en formato raw
@@ -79,3 +87,8 @@ def run_data_pipeline():
     # Preprocesar las etiquetas (formato one-hot encoding)
     y_train_one_hot, y_test_one_hot = preprocess_labels(y_train, y_test)
     print("Etiquetas preprocesadas listas.")
+
+    # Guardar los datos preprocesados
+    save_preprocessed_data(x_train_mlp, x_test_mlp, x_train_cnn, x_test_cnn, y_train_one_hot, y_test_one_hot)
+    print("Imagenes y etiquetas preprocesadas guardadas en /data/preprocessed")
+

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -8,7 +8,7 @@ def download_raw_data():
     (x_train, y_train), (x_test, y_test) = mnist.load_data()
 
     # Directorio para guardar MNIST y comprobacion de su existencia
-    output_dir = './data/raw'
+    output_dir = os.path.join('.', 'data', 'raw')
     os.makedirs(output_dir, exist_ok=True)
 
     # Rutas de guardado para las imagenes y etiquetas de entrenamiento y testeo 

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -1,1 +1,5 @@
-# Script for data pipeline management
+import tensorflow as tf
+import numpy as np
+import os
+
+

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -46,8 +46,8 @@ def load_data():
     return (train_images, train_labels), (test_images, test_labels)
 
 def save_preprocessed_data(x_train_mlp, x_test_mlp, x_train_cnn, x_test_cnn, y_train, y_test):
-    """Guarda los datos preprocesados en /data/preprocessed"""
-    preprocessed_dir = os.path.join('.', 'data', 'preprocessed')
+    """Guarda los datos preprocesados en /data/processed"""
+    preprocessed_dir = os.path.join('.', 'data', 'processed')
     os.makedirs(preprocessed_dir, exist_ok=True)
 
     # Rutas de guardado para las imagenes preprocesadas
@@ -90,7 +90,7 @@ def run_data_pipeline():
 
     # Guardar los datos preprocesados
     save_preprocessed_data(x_train_mlp, x_test_mlp, x_train_cnn, x_test_cnn, y_train_one_hot, y_test_one_hot)
-    print("Imagenes y etiquetas preprocesadas guardadas en /data/preprocessed")
+    print("Imagenes y etiquetas preprocesadas guardadas en /data/processed")
 
 if __name__ == '__main__':
     # Ejecutar el data_pipeline

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -29,7 +29,14 @@ def load_data():
     """Carga los datos de MNIST en formato raw"""
     raw_dir = os.path.join('.', 'data', 'raw')
 
+    # Rutas de los archivos raw 
     train_images_file = os.path.join(raw_dir, 'train_images.raw')
     train_labels_file = os.path.join(raw_dir, 'train_labels.raw')
     test_images_file = os.path.join(raw_dir, 'test_images.raw')
     test_labels_file = os.path.join(raw_dir, 'test_labels.raw')
+
+    # Cargar imagenes y etiquetas desde los archivos raw 
+    train_images = np.fromfile(train_images_file, dtype=np.uint8).reshape(-1, 28, 28)
+    train_labels = np.fromfile(train_labels_file, dtype=np.uint8)
+    test_images = np.fromfile(test_images_file, dtype=np.uint8).reshape(-1, 28, 28)
+    test_labels = np.fromfile(test_labels_file, dtype=np.uint8)

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -50,8 +50,14 @@ def save_preprocessed_data(x_train_mlp, x_test_mlp, x_train_cnn, x_test_cnn):
     preprocessed_dir = os.path.join('.', 'data', 'preprocessed')
     os.makedirs(preprocessed_dir, exist_ok=True)
 
+    # Rutas de guardado para las imagenes preprocesadas
+    train_mlp_file = os.path.join(preprocessed_dir, 'train_mlp.npy')
+    test_mlp_file = os.path.join(preprocessed_dir, 'test_mlp.npy')
+    train_cnn_file = os.path.join(preprocessed_dir, 'train_cnn.npy')
+    test_cnn_file = os.path.join(preprocessed_dir, 'test_cnn.npy')
+
 def run_data_pipeline():
-    """Organiza la descarga, carga y procesamiento de los datos de MNIST"""
+    """Organiza la descarga, carga y procesamiento de los datos sde MNIST"""
     # Descargar y guardar los datos de MNIST en formato raw
     download_raw_data()
 

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -11,8 +11,14 @@ def download_raw_data():
     output_dir = './data/raw'
     os.makedirs(output_dir, exist_ok=True)
 
-    # Rutas de guardado para las imágenes y etiquetas de entrenamiento y testeo 
+    # Rutas de guardado para las imagenes y etiquetas de entrenamiento y testeo 
     train_images_file = os.path.join(output_dir, 'train_images.raw')
     train_labels_file = os.path.join(output_dir, 'train_labels.raw')
     test_images_file = os.path.join(output_dir, 'test_images.raw')
     test_labels_file = os.path.join(output_dir, 'test_labels.raw')
+
+    # Guardado de las imagenes y etiquetas en formato raw
+    x_train.tofile(train_images_file)
+    y_train.tofile(train_labels_file)
+    x_test.tofile(test_images_file)
+    y_test.tofile(test_labels_file)

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -45,6 +45,11 @@ def load_data():
     print("Datos MNIST cargados (y procesados) desde /data/raw")
     return (train_images, train_labels), (test_images, test_labels)
 
+def save_preprocessed_data(x_train_mlp, x_test_mlp, x_train_cnn, x_test_cnn):
+    """Guarda los datos preprocesados en /data/preprocessed"""
+    preprocessed_dir = os.path.join('.', 'data', 'preprocessed')
+    os.makedirs(preprocessed_dir, exist_ok=True)
+
 def run_data_pipeline():
     """Organiza la descarga, carga y procesamiento de los datos de MNIST"""
     # Descargar y guardar los datos de MNIST en formato raw

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -10,3 +10,9 @@ def download_raw_data():
     # Directorio para guardar MNIST y comprobacion de su existencia
     output_dir = './data/raw'
     os.makedirs(output_dir, exist_ok=True)
+
+    # Rutas de guardado para las imágenes y etiquetas de entrenamiento y testeo 
+    train_images_file = os.path.join(output_dir, 'train_images.raw')
+    train_labels_file = os.path.join(output_dir, 'train_labels.raw')
+    test_images_file = os.path.join(output_dir, 'test_images.raw')
+    test_labels_file = os.path.join(output_dir, 'test_labels.raw')

--- a/src/data_preprocessing.py
+++ b/src/data_preprocessing.py
@@ -1,4 +1,5 @@
 import numpy as np
+from tensorflow.keras.utils import to_categorical
 
 def preprocess_data_for_mlp(x_train, x_test):
     """Realiza el preprocesamiento para la MLP (aplanado de imágenes)."""
@@ -21,3 +22,11 @@ def preprocess_data_for_cnn(x_train, x_test):
     x_test_cnn = np.expand_dims(x_test_cnn, axis=-1)
 
     return x_train_cnn, x_test_cnn
+
+def preprocess_labels(y_train, y_test):
+    """Realiza el preprocesamiento de las etiquetas (one-hot encoding)."""
+    # Convertir las etiquetas a one-hot encoding
+    y_train_one_hot = to_categorical(y_train, num_classes=10)
+    y_test_one_hot = to_categorical(y_test, num_classes=10)
+
+    return y_train_one_hot, y_test_one_hot

--- a/src/data_preprocessing.py
+++ b/src/data_preprocessing.py
@@ -1,5 +1,5 @@
 import numpy as np
-from tensorflow.keras.utils import to_categorical
+import tensorflow as tf
 
 def preprocess_data_for_mlp(x_train, x_test):
     """Realiza el preprocesamiento para la MLP (aplanado de imágenes)."""
@@ -26,7 +26,7 @@ def preprocess_data_for_cnn(x_train, x_test):
 def preprocess_labels(y_train, y_test):
     """Realiza el preprocesamiento de las etiquetas (one-hot encoding)."""
     # Convertir las etiquetas a one-hot encoding
-    y_train_one_hot = to_categorical(y_train, num_classes=10)
-    y_test_one_hot = to_categorical(y_test, num_classes=10)
+    y_train_one_hot = tf.keras.utils.to_categorical(y_train, num_classes=10)
+    y_test_one_hot = tf.keras.utils.to_categorical(y_test, num_classes=10)
 
     return y_train_one_hot, y_test_one_hot


### PR DESCRIPTION
Se ha creado data_pipeline.py y escrito (en ese script) el codigo necesario para el manejo de los datos de MNIST desde la descarga, carga, preprocesado (mediante data_processing.py) y guardado de lo necesario. Para ejecutar este script, se realiza desde el directorio PAM/ mediante "python -m scripts.data_pipeline" para asi realizar las importaciones de los modulos de manera correcta.
