### PR TITLE
Agregar el script models.py para construir los modelos CNN y MLP

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -3,11 +3,24 @@ from tensorflow.keras.layers import Dense, Flatten, Conv2D, MaxPooling2D
 
 def build_mlp_model():
     """Construye un modelo de red neuronal multicapa (MLP)"""
-    model = Sequential([
+    mlp_model = Sequential([
         Flatten(input_shape=(784, )),
         Dense(256, activation='relu'),
         Dense(128, activation='relu'),
         Dense(64, activation='relu'),
         Dense(10, activation='softmax')
     ])
-    return model
+    return mlp_model
+
+def build_cnn_model():
+    """Construye un modelo de red neuronal convolucional (CNN)"""
+    cnn_model = Sequential([
+        Conv2D(32, (3, 3), activation='relu', input_shape=(28, 28, 1)),
+        MaxPooling2D((2, 2)),
+        Conv2D(64, (3, 3), activation='relu'),
+        MaxPooling2D((2, 2)),
+        Flatten(),
+        Dense(128, activation='relu'),
+        Dense(10, activation='softmax')
+    ])
+    return cnn_model

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,2 @@
+from tensorflow.keras.models import Sequential 
+from tensorflow.keras.layers import Dense, Flatten, Conv2D, MaxPooling2D

--- a/src/models.py
+++ b/src/models.py
@@ -1,2 +1,13 @@
 from tensorflow.keras.models import Sequential 
 from tensorflow.keras.layers import Dense, Flatten, Conv2D, MaxPooling2D
+
+def build_mlp_model():
+    """Construye un modelo de red neuronal multicapa (MLP)"""
+    model = Sequential([
+        Flatten(input_shape=(784, )),
+        Dense(256, activation='relu'),
+        Dense(128, activation='relu'),
+        Dense(64, activation='relu'),
+        Dense(10, activation='softmax')
+    ])
+    return model


### PR DESCRIPTION
Se ha creado y agregado dos funciones al script models.py para poder construir un modelo CNN y otro modelo MLP preparados para trabajar con los datos de MNIST ya procesados.