### PR TITLE
Agregar el script train_models.py para el entrenamiento de los modelos MLP y CNN

### DIFF
--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -41,3 +41,9 @@ def train_mlp():
     os.makedirs(os.path.join('.', 'models'), exist_ok=True)
     mlp_model.save(os.path.join('.', 'models', 'mlp_model.h5'))
     print("Modelo MLP entrenado y guardado.")
+
+def train_cnn():
+    """Entrena un modelo de red neuronal convolucional (CNN) para MNIST y lo guarda"""
+    # Cargar los datos preprocesados para la CNN
+    x_train, x_test, y_train, y_test = load_processed_data('cnn')
+    

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -22,7 +22,7 @@ def load_processed_data(model_type):
     return x_train, x_test, y_train, y_test
 
 def train_mlp():
-    """Entrena un modelo de red neuronal multicapa (MLP) para MNIST"""
+    """Entrena un modelo de red neuronal multicapa (MLP) para MNIST y lo guarda"""
     # Cargar los datos preprocesados para la MLP
     x_train, x_test, y_train, y_test = load_processed_data('mlp')
 
@@ -33,3 +33,11 @@ def train_mlp():
         loss='categorical_crossentropy', 
         metrics=['accuracy']
     )
+
+    # Entrenar el modelo MLP
+    mlp_model.fit(x_train, y_train, epochs=10, batch_size=32, validation_data=(x_test, y_test))
+
+    # Guardar el modelo entrenado
+    os.makedirs(os.path.join('.', 'models'), exist_ok=True)
+    mlp_model.save(os.path.join('.', 'models', 'mlp_model.h5'))
+    print("Modelo MLP entrenado y guardado.")

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -62,3 +62,10 @@ def train_cnn():
     os.makedirs(os.path.join('.', 'models'), exist_ok=True)
     cnn_model.save(os.path.join('.', 'models', 'cnn_model.h5'))
     print("Modelo CNN entrenado y guardado.")
+
+if __name__ == '__main__':
+    # Con los datos preprocesados de /data/preprocessed:
+    # Se entrena y guarda el modelo MLP
+    train_mlp()
+    # Se entrena y guarda el modelo CNN
+    train_cnn()

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -46,4 +46,11 @@ def train_cnn():
     """Entrena un modelo de red neuronal convolucional (CNN) para MNIST y lo guarda"""
     # Cargar los datos preprocesados para la CNN
     x_train, x_test, y_train, y_test = load_processed_data('cnn')
-    
+
+    # Crear y compilar el modelo CNN
+    cnn_model = build_cnn_model()
+    cnn_model.compile(
+        optimizer=Adam(learning_rate=0.001), 
+        loss='categorical_crossentropy', 
+        metrics=['accuracy']
+    )

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -20,3 +20,8 @@ def load_processed_data(model_type):
     y_test = np.load(os.path.join(processed_dir, 'test_labels.npy'))
 
     return x_train, x_test, y_train, y_test
+
+def train_mlp():
+    """Entrena un modelo de red neuronal multicapa (MLP) para MNIST"""
+    # Cargar los datos preprocesados para la MLP
+    x_train, x_test, y_train, y_test = load_processed_data('mlp')

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -1,0 +1,4 @@
+import os
+import numpy as np
+from tensorflow.keras.optimizers import Adam
+from src.models import build_mlp_model, build_cnn_model

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -25,3 +25,11 @@ def train_mlp():
     """Entrena un modelo de red neuronal multicapa (MLP) para MNIST"""
     # Cargar los datos preprocesados para la MLP
     x_train, x_test, y_train, y_test = load_processed_data('mlp')
+
+    # Crear y compilar el modelo MLP
+    mlp_model = build_mlp_model()
+    mlp_model.compile(
+        optimizer=Adam(learning_rate=0.001), 
+        loss='categorical_crossentropy', 
+        metrics=['accuracy']
+    )

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -54,3 +54,11 @@ def train_cnn():
         loss='categorical_crossentropy', 
         metrics=['accuracy']
     )
+
+    # Entrenar el modelo CNN
+    cnn_model.fit(x_train, y_train, epochs=10, batch_size=32, validation_data=(x_test, y_test))
+
+    # Guardar el modelo entrenado
+    os.makedirs(os.path.join('.', 'models'), exist_ok=True)
+    cnn_model.save(os.path.join('.', 'models', 'cnn_model.h5'))
+    print("Modelo CNN entrenado y guardado.")

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -2,3 +2,21 @@ import os
 import numpy as np
 from tensorflow.keras.optimizers import Adam
 from src.models import build_mlp_model, build_cnn_model
+
+def load_processed_data(model_type):
+    """Carga los datos procesados de MNIST"""
+    processed_dir = os.path.join('.', 'data', 'processed')
+
+    # Cargar las imagenes preprocesados de MNIST segun el tipo de modelo
+    if(model_type == 'mlp'):
+        x_train = np.load(os.path.join(processed_dir, 'train_mlp.npy'))
+        x_test = np.load(os.path.join(processed_dir, 'test_mlp.npy'))
+    elif(model_type == 'cnn'):
+        x_train = np.load(os.path.join(processed_dir, 'train_cnn.npy'))
+        x_test = np.load(os.path.join(processed_dir, 'test_cnn.npy'))
+
+    # Cargar las etiquetas preprocesadas de MNIST
+    y_train = np.load(os.path.join(processed_dir, 'train_labels.npy'))
+    y_test = np.load(os.path.join(processed_dir, 'test_labels.npy'))
+
+    return x_train, x_test, y_train, y_test


### PR DESCRIPTION
Se ha creado y modificado el script train_models.py para manejar todo lo concerniente al entrenamiento de los modelos MLP y CNN asi tambien como el guardado de los modelos ya entrenados (en formato h5)