### PR TITLE
Agregar archivo config.yaml

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,1 +1,13 @@
-# Configuration parameters
+# Configuracion del entrenamiento de los modelos
+training:
+  epochs: 10
+  batch_size: 32
+  learning_rate: 0.001
+  optimizer: 'adam'
+  loss: 'categorical_crossentropy'
+  metrics: ['accuracy']
+
+# Funciones de activacion
+activation_functions:
+  - relu: 'relu'
+  - softmax: 'softmax'

--- a/config/logging.yaml
+++ b/config/logging.yaml
@@ -1,1 +1,0 @@
-# Logging configuration

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -2,6 +2,19 @@ import os
 import numpy as np
 from tensorflow.keras.optimizers import Adam
 from src.models import build_mlp_model, build_cnn_model
+import yaml
+
+# Abrir el archivo de configuracion
+with open(os.path.join('.', 'config', 'config.yaml'), 'r') as file:
+    config = yaml.safe_load(file)
+
+# Variables globales
+EPOCHS = config['training']['epochs']
+BATCH_SIZE = config['training']['batch_size']
+LEARNING_RATE = config['training']['learning_rate']
+OPTIMIZER = config['training']['optimizer']
+LOSS = config['training']['loss']
+METRICS = config['training']['metrics']
 
 def load_processed_data(model_type):
     """Carga los datos procesados de MNIST"""
@@ -29,13 +42,13 @@ def train_mlp():
     # Crear y compilar el modelo MLP
     mlp_model = build_mlp_model()
     mlp_model.compile(
-        optimizer=Adam(learning_rate=0.001), 
-        loss='categorical_crossentropy', 
-        metrics=['accuracy']
+        optimizer=Adam(learning_rate=LEARNING_RATE), 
+        loss=LOSS, 
+        metrics=METRICS
     )
 
     # Entrenar el modelo MLP
-    mlp_model.fit(x_train, y_train, epochs=10, batch_size=32, validation_data=(x_test, y_test))
+    mlp_model.fit(x_train, y_train, epochs=EPOCHS, batch_size=BATCH_SIZE, validation_data=(x_test, y_test))
 
     # Guardar el modelo entrenado
     os.makedirs(os.path.join('.', 'models'), exist_ok=True)
@@ -50,13 +63,13 @@ def train_cnn():
     # Crear y compilar el modelo CNN
     cnn_model = build_cnn_model()
     cnn_model.compile(
-        optimizer=Adam(learning_rate=0.001), 
-        loss='categorical_crossentropy', 
-        metrics=['accuracy']
+        optimizer=Adam(learning_rate=LEARNING_RATE), 
+        loss=LOSS, 
+        metrics=METRICS
     )
 
     # Entrenar el modelo CNN
-    cnn_model.fit(x_train, y_train, epochs=10, batch_size=32, validation_data=(x_test, y_test))
+    cnn_model.fit(x_train, y_train, epochs=EPOCHS, batch_size=BATCH_SIZE, validation_data=(x_test, y_test))
 
     # Guardar el modelo entrenado
     os.makedirs(os.path.join('.', 'models'), exist_ok=True)
@@ -69,3 +82,6 @@ if __name__ == '__main__':
     train_mlp()
     # Se entrena y guarda el modelo CNN
     train_cnn()
+
+# Cerrar el archivo de configuracion
+file.close()

--- a/src/models.py
+++ b/src/models.py
@@ -1,26 +1,35 @@
 from tensorflow.keras.models import Sequential 
 from tensorflow.keras.layers import Dense, Flatten, Conv2D, MaxPooling2D
+import yaml
+import os
+
+# Abrir el archivo de configuracion
+with open(os.path.join('.', 'config', 'config.yaml'), 'r') as file:
+    config = yaml.safe_load(file)
 
 def build_mlp_model():
     """Construye un modelo de red neuronal multicapa (MLP)"""
     mlp_model = Sequential([
         Flatten(input_shape=(784, )),
-        Dense(256, activation='relu'),
-        Dense(128, activation='relu'),
-        Dense(64, activation='relu'),
-        Dense(10, activation='softmax')
+        Dense(256, activation=config['activation-functions']['relu']),
+        Dense(128, activation=config['activation-functions']['relu']),
+        Dense(64, activation=config['activation-functions']['relu']),
+        Dense(10, activation=config['activation-functions']['softmax'])
     ])
     return mlp_model
 
 def build_cnn_model():
     """Construye un modelo de red neuronal convolucional (CNN)"""
     cnn_model = Sequential([
-        Conv2D(32, (3, 3), activation='relu', input_shape=(28, 28, 1)),
+        Conv2D(32, (3, 3), activation=config['activation-functions']['relu'], input_shape=(28, 28, 1)),
         MaxPooling2D((2, 2)),
-        Conv2D(64, (3, 3), activation='relu'),
+        Conv2D(64, (3, 3), activation=config['activation-functions']['relu']),
         MaxPooling2D((2, 2)),
         Flatten(),
-        Dense(128, activation='relu'),
-        Dense(10, activation='softmax')
+        Dense(128, activation=config['activation-functions']['relu']),
+        Dense(10, activation=config['activation-functions']['softmax'])
     ])
     return cnn_model
+
+# Cerrar el archivo de configuracion
+file.close()

--- a/src/models.py
+++ b/src/models.py
@@ -7,27 +7,31 @@ import os
 with open(os.path.join('.', 'config', 'config.yaml'), 'r') as file:
     config = yaml.safe_load(file)
 
+# Variables globales
+relu = config['activation_functions'][0]['relu']
+softmax = config['activation_functions'][1]['softmax']
+
 def build_mlp_model():
     """Construye un modelo de red neuronal multicapa (MLP)"""
     mlp_model = Sequential([
         Flatten(input_shape=(784, )),
-        Dense(256, activation=config['activation-functions']['relu']),
-        Dense(128, activation=config['activation-functions']['relu']),
-        Dense(64, activation=config['activation-functions']['relu']),
-        Dense(10, activation=config['activation-functions']['softmax'])
+        Dense(256, activation=relu),
+        Dense(128, activation=relu),
+        Dense(64, activation=relu),
+        Dense(10, activation=softmax)
     ])
     return mlp_model
 
 def build_cnn_model():
     """Construye un modelo de red neuronal convolucional (CNN)"""
     cnn_model = Sequential([
-        Conv2D(32, (3, 3), activation=config['activation-functions']['relu'], input_shape=(28, 28, 1)),
+        Conv2D(32, (3, 3), activation=relu, input_shape=(28, 28, 1)),
         MaxPooling2D((2, 2)),
-        Conv2D(64, (3, 3), activation=config['activation-functions']['relu']),
+        Conv2D(64, (3, 3), activation=relu),
         MaxPooling2D((2, 2)),
         Flatten(),
-        Dense(128, activation=config['activation-functions']['relu']),
-        Dense(10, activation=config['activation-functions']['softmax'])
+        Dense(128, activation=relu),
+        Dense(10, activation=softmax)
     ])
     return cnn_model
 


### PR DESCRIPTION
Se ha modificado el archivo config.yaml para añadir las configuraciones sobre el entrenamiento de los modelos CNN y MLP (epochs, funciones de activacion, batch size, etc.) así como se ha eliminado el archivo logging.yaml. Además, se ha implementado el uso de config.yaml en train_models.py y models.py